### PR TITLE
CSC-27 Reduce signing cert validity

### DIFF
--- a/docs/CSBR.md
+++ b/docs/CSBR.md
@@ -2031,7 +2031,7 @@ Subscribers and Signing Services MAY sign Code at any point in the development o
 
 The validity period for a Code Signing Certificate issued to a Subscriber or Signing Service MUST NOT exceed 39 months.
 
-For all all Code Signing Certificates issued after June 15, 2025,  the validity period for the Code Signing Certificate issued to a Subscriber MUST NOT exceed 460 days.
+For all Code Signing Certificates issued after June 15, 2025,  the validity period for the Code Signing Certificate issued to a Subscriber MUST NOT exceed 460 days.
 
 The Timestamp Certificate validity period MUST NOT exceed 135 months. The Timestamp Certificate Key Pair MUST meet the requirements in [Section 6.1.5](#615-key-sizes). The CA or Timestamp Authority SHALL NOT use a Private Key associated with a Timestamp Certificate more than 15 months after the `notBefore` date of a Timestamp Certificate. 
 

--- a/docs/CSBR.md
+++ b/docs/CSBR.md
@@ -2031,6 +2031,8 @@ Subscribers and Signing Services MAY sign Code at any point in the development o
 
 The validity period for a Code Signing Certificate issued to a Subscriber or Signing Service MUST NOT exceed 39 months.
 
+For all all Code Signing Certificates issued after June 15, 2025,  the validity period for the Code Signing Certificate issued to a Subscriber MUST NOT exceed 460 days.
+
 The Timestamp Certificate validity period MUST NOT exceed 135 months. The Timestamp Certificate Key Pair MUST meet the requirements in [Section 6.1.5](#615-key-sizes). The CA or Timestamp Authority SHALL NOT use a Private Key associated with a Timestamp Certificate more than 15 months after the `notBefore` date of a Timestamp Certificate. 
 
 Effective April 15, 2025, Private Keys associated with Timestamp Certificates issued for greater than 15 months MUST be removed from the Hardware Crypto Module protecting the Private Key within 18 months after issuance of the Timestamp Certificate. For Timestamp Certificates issued on or after June 1, 2024, the CA SHALL log the removal of the Private Key from the Hardware Crypto Module through means of a key deletion ceremony performed by the CA and witnessed and signed-off by at least two Trusted Role members. The CA MAY also perform a key destruction ceremony, meaning that all copies of that private key are unequivocally/securely destroyed (i.e. without a way to recover the key), including any instance of the key as part of a backup, to satisfy this requirement.


### PR DESCRIPTION
Considering the potential broad impacts of a revocation action with a Code Signing Certificate issued to the current max validity of 39 months, I’d like to propose we reduce the max validity to 460 days (~15 months). This would reduce the amount of potentially impacted good code signed by a victim of a takeover attacks and help limit the time an attacker has to abuse a Code Signing Certificate. With that in mind, I’d like to propose the following language to be added to reduce the max validity for Code Signing Certificates to 460 days which includes an effective date of June 15, 2025, for all newly issued Code Signing Certificates.