### PR TITLE
CSC-31: Maximum Validity Reduction (#48)

### DIFF
--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -7,7 +7,7 @@ jobs:
         document:
           - 'CSBR.md'
     name: Build ${{ matrix.document }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4

--- a/docs/CSBR.md
+++ b/docs/CSBR.md
@@ -1,14 +1,14 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted Code Signing Certificates
 
-subtitle: Version 3.9.0
+subtitle: Version 3.10.0
 
 author:
   - CA/Browser Forum
-date: August 1, 2024
+date: November X, 2025
 
 copyright: |
-  Copyright 2024 CA/Browser Forum
+  Copyright 2025 CA/Browser Forum
 
   This work is licensed under the Creative Commons Attribution 4.0 International license.
 ---
@@ -61,7 +61,7 @@ The following Certificate Policy Identifier is reserved for use by CAs as a requ
 | 3.7      | CSC-22     | High risk changes                                                                                                 | 28 February 2024  |
 | 3.8      | CSC-25     | Import EV Guidelines into the Code Signing Baseline Requirements                                                  | 1 August 2024     |
 | 3.9      | CSC-26     | Timestamping Private Key Protection                                                                               | 1 August 2024     |
-
+| 3.10     | CSC-31     | Maximum Validity Reduction                           | XX November 2025     |
 ### 1.2.2 Relevant Dates
 
 | **Compliance** | **Section(s)** | **Summary Description (See Full Text for Details)**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
@@ -80,6 +80,7 @@ The following Certificate Policy Identifier is reserved for use by CAs as a requ
 | 2024-06-15     | 8.4.2          | For Audit Periods starting after June 30, 2024, the Signing Service MUST undergo a conformity assessment audit for compliance with these Requirements performed in accordance with one of the schemes specified in Section 8.4.2.                                                                                                                                                                                                                                                                                                                                                                  |
 | 2025-03-15     | 3.2.10         | Prior to the use of an Incorporating Agency or Registration Agency to fulfill these verification requirements, the CA MUST publicly disclose Agency Information about the Incorporating Agency or Registration Agency.                                                                                                                                                                                                                                                                                                                                                                             |
 | 2025-04-15     | 6.2.7.2        | Effective April 15, 2025, a Timestamp Authority MUST protect Private Keys associated with its Root CA certificates and Subordinate CA certificates containing the "Time Stamping" EKU in offline Hardware Crypto Module.   |
+| 2026-03-01     | 6.3.2       | For Code Signing Certificates issued on or after March 1st, 2026, the validity period MUST NOT exceed 460 days.   |
 
 ## 1.3 PKI participants
 

--- a/docs/CSBR.md
+++ b/docs/CSBR.md
@@ -5,7 +5,7 @@ subtitle: Version 3.10.0
 
 author:
   - CA/Browser Forum
-date: November X, 2025
+date: November 17, 2025
 
 copyright: |
   Copyright 2025 CA/Browser Forum
@@ -61,7 +61,7 @@ The following Certificate Policy Identifier is reserved for use by CAs as a requ
 | 3.7      | CSC-22     | High risk changes                                                                                                 | 28 February 2024  |
 | 3.8      | CSC-25     | Import EV Guidelines into the Code Signing Baseline Requirements                                                  | 1 August 2024     |
 | 3.9      | CSC-26     | Timestamping Private Key Protection                                                                               | 1 August 2024     |
-| 3.10     | CSC-31     | Maximum Validity Reduction                           | XX November 2025     |
+| 3.10     | CSC-31     | Maximum Validity Reduction                           | 7 November 2025     |
 ### 1.2.2 Relevant Dates
 
 | **Compliance** | **Section(s)** | **Summary Description (See Full Text for Details)**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |

--- a/docs/CSBR.md
+++ b/docs/CSBR.md
@@ -2029,7 +2029,7 @@ CAs SHALL ensure that the Subscriber’s Private Key is generated, stored, and u
 
 Subscribers and Signing Services MAY sign Code at any point in the development or distribution process. Code Signatures may be verified at any time, including during download, unpacking, installation, reinstallation, or execution, or during a forensic investigation.
 
-The validity period for a Code Signing Certificate issued to a Subscriber or Signing Service MUST NOT exceed 39 months.
+For Code Signing Certificates issued before March 1st, 2026, the validity period MUST NOT exceed 39 months. For Code Signing Certificates issued on or after March 1st, 2026, the validity period MUST NOT exceed 460 days.
 
 The Timestamp Certificate validity period MUST NOT exceed 135 months. The Timestamp Certificate Key Pair MUST meet the requirements in [Section 6.1.5](#615-key-sizes). The CA or Timestamp Authority SHALL NOT use a Private Key associated with a Timestamp Certificate more than 15 months after the `notBefore` date of a Timestamp Certificate. 
 


### PR DESCRIPTION
* Update CSBR.md for proposed validity period change

Updating to mostly match ian's original verbiage. However, given that we want at least 6 months to reflect the change after enforcmeent, setting the date to January 1st of 2026 instead of the original June 15th of 2025

* Update CSBR.md

removing previous line to avoid confusion, and updating to March

* Update docs/CSBR.md

accepting change in verbiage to be clear on certificate life for certificates issued before



* Update docs/CSBR.md

removing an extra space



---------