### PR TITLE
Ballot CSC-32: Make a Reserved Policy OID mandatory in the CertificatePolicies extension for Subscriber certificates

### DIFF
--- a/docs/CSBR.md
+++ b/docs/CSBR.md
@@ -2459,7 +2459,8 @@ A Subordinate CA MUST represent, in its Certificate Policy and/or Certification 
 
 ####  7.1.6.4  Subscriber Certificates
 
-A Certificate issued to a Subscriber MUST contain one or more policy identifier(s), defined by the CA, in the Certificate's certificatePolicies extension that indicates adherence to and compliance with these Requirements. CAs complying with these Requirements MAY also assert the reserved policy OIDs in such Certificates.
+A Certificate issued to a Subscriber MUST contain exactly one of the reserved policy OIDs specified in Section 7.1.6.1 in the Certificate's CertificatePolicies extension. 
+CAs complying with these Requirements MAY also assert or more policy identifier(s), defined by the CA, in the Certificate's CertificatePolicies extension, that indicates adherence to and compliance with these Requirements.
 
 The CA MUST document in its Certificate Policy or Certification Practice Statement that the Certificates it issues containing the specified policy identifier(s) are managed in accordance with these Requirements.
 
@@ -3036,3 +3037,4 @@ jurisdictionCountryName ATTRIBUTE ::= {
 
 END
 ```
+

--- a/docs/CSBR.md
+++ b/docs/CSBR.md
@@ -2461,7 +2461,7 @@ A Subordinate CA MUST represent, in its Certificate Policy and/or Certification 
 
 Effective September 15, 2026 a Certificate issued to a Subscriber MUST contain exactly one of the reserved policy OIDs specified in Section 7.1.6.1 in the Certificate's CertificatePolicies extension.
 
-CAs complying with these Requirements MAY also assert or more policy identifier(s), defined by the CA, in the Certificate's CertificatePolicies extension, that indicates adherence to and compliance with these Requirements.
+CAs complying with these Requirements MAY also assert one or more policy identifier(s), defined by the CA, in the Certificate's CertificatePolicies extension, that indicates adherence to and compliance with these Requirements.
 
 The CA MUST document in its Certificate Policy or Certification Practice Statement that the Certificates it issues containing the specified policy identifier(s) are managed in accordance with these Requirements.
 

--- a/docs/CSBR.md
+++ b/docs/CSBR.md
@@ -2459,7 +2459,8 @@ A Subordinate CA MUST represent, in its Certificate Policy and/or Certification 
 
 ####  7.1.6.4  Subscriber Certificates
 
-A Certificate issued to a Subscriber MUST contain exactly one of the reserved policy OIDs specified in Section 7.1.6.1 in the Certificate's CertificatePolicies extension. 
+Effective September 15, 2026 a Certificate issued to a Subscriber MUST contain exactly one of the reserved policy OIDs specified in Section 7.1.6.1 in the Certificate's CertificatePolicies extension.
+
 CAs complying with these Requirements MAY also assert or more policy identifier(s), defined by the CA, in the Certificate's CertificatePolicies extension, that indicates adherence to and compliance with these Requirements.
 
 The CA MUST document in its Certificate Policy or Certification Practice Statement that the Certificates it issues containing the specified policy identifier(s) are managed in accordance with these Requirements.


### PR DESCRIPTION
This ballot updates the “Baseline Requirements for the Issuance and Management of Publicly‐Trusted Code Signing Certificates“ version 3.10 in order to modify the requirements regarding Certificate policy object identifiers (OIDs) in Subscriber Certificates. The main goals of this ballot are to:
*  Require the inclusion of a Reserved Policy OID in the CertificatePolicies extension
*  Make it optional to include other CA-defined Reserved Policy OID(s) in the CertificatePolicies extension
